### PR TITLE
fixed WriteDump syntax for Lucee 5

### DIFF
--- a/USPSCannedTests.cfm
+++ b/USPSCannedTests.cfm
@@ -19,7 +19,7 @@ variables.Verify1 = variables.usps.AddressValidate(
 	City = 'Greenbelt',
 	State = 'MD'
 );
-WriteDump(var="#variables.Verify1#" label="Verify1");
+WriteDump(var="#variables.Verify1#", label="Verify1");
 
 
 // USPS Canned Test: This test will also cleanse the address and completes the ZIP Code.
@@ -30,21 +30,21 @@ variables.Verify2 = variables.usps.AddressValidate(
 	Zip5 = '20770',
 	Zip4 = '1440'
 );
-WriteDump(var="#variables.Verify2#" label="Verify2");
+WriteDump(var="#variables.Verify2#", label="Verify2");
 
 
 // USPS Canned Test: This API is used to find the City and State associated with a ZIP Code.
 variables.CityStateLookup1 = variables.usps.CityStateLookup(
 	Zip5 = '90210'
 );
-WriteDump(var="#variables.CityStateLookup1#" label="CityStateLookup1");
+WriteDump(var="#variables.CityStateLookup1#", label="CityStateLookup1");
 
 
 // USPS Canned Test: This test demonstrates the use of characteristic identifiers to allow grouping multiple requests into the same transaction.
 variables.CityStateLookup2 = variables.usps.CityStateLookup(
 	Zip5 = '20770'
 );
-WriteDump(var="#variables.CityStateLookup2#" label="CityStateLookup2");
+WriteDump(var="#variables.CityStateLookup2#", label="CityStateLookup2");
 
 
 // USPS Canned Test
@@ -53,7 +53,7 @@ variables.ZipCodeLookup1 = variables.usps.ZipCodeLookup(
 	City = 'Greenbelt',
 	State = 'MD'
 );
-WriteDump(var="#variables.ZipCodeLookup1#" label="ZipCodeLookup1");
+WriteDump(var="#variables.ZipCodeLookup1#", label="ZipCodeLookup1");
 
 
 // USPS Canned Test
@@ -62,21 +62,21 @@ variables.ZipCodeLookup2 = variables.usps.ZipCodeLookup(
 	City = 'Old Lyme',
 	State = 'CT'
 );
-WriteDump(var="#variables.ZipCodeLookup2#" label="ZipCodeLookup2");
+WriteDump(var="#variables.ZipCodeLookup2#", label="ZipCodeLookup2");
 
 
 // USPS Canned Test
 variables.Track1 = variables.usps.Track(
 	TrackID = 'EJ958083578US'
 );
-WriteDump(var="#variables.Track1#" label="Track1");
+WriteDump(var="#variables.Track1#", label="Track1");
 
 
 // USPS Canned Test
 variables.Track2 = variables.usps.Track(
 	TrackID = 'EJ958088694US'
 );
-WriteDump(var="#variables.Track2#" label="Track2");
+WriteDump(var="#variables.Track2#", label="Track2");
 
 
 // USPS Canned Test
@@ -84,7 +84,7 @@ variables.ExpressMailCommitment1 = variables.usps.ExpressMailCommitment(
 	OriginZIP = '207',
 	DestinationZIP = '11210'
 );
-WriteDump(var="#variables.ExpressMailCommitment1#" label="ExpressMailCommitment1");
+WriteDump(var="#variables.ExpressMailCommitment1#", label="ExpressMailCommitment1");
 
 
 // USPS Canned Test
@@ -93,7 +93,7 @@ variables.ExpressMailCommitment2 = variables.usps.ExpressMailCommitment(
 	DestinationZIP = '11210',
 	Date = '05-Aug-2004'
 );
-WriteDump(var="#variables.ExpressMailCommitment2#" label="ExpressMailCommitment2");
+WriteDump(var="#variables.ExpressMailCommitment2#", label="ExpressMailCommitment2");
 
 
 // USPS Canned Test
@@ -106,7 +106,7 @@ variables.CarrierPickupAvailability1 = variables.usps.CarrierPickupAvailability(
 	ZIP5 = '77058',
 	ZIP4 = '1234'
 );
-WriteDump(var="#variables.CarrierPickupAvailability1#" label="CarrierPickupAvailability1");
+WriteDump(var="#variables.CarrierPickupAvailability1#", label="CarrierPickupAvailability1");
 
 
 // USPS Canned Test
@@ -114,7 +114,7 @@ variables.CarrierPickupAvailability2 = variables.usps.CarrierPickupAvailability(
 	Address2 = '1390 Market Street',
 	ZIP5 = '77058'
 );
-WriteDump(var="#variables.CarrierPickupAvailability2#" label="CarrierPickupAvailability2");
+WriteDump(var="#variables.CarrierPickupAvailability2#", label="CarrierPickupAvailability2");
 
 
 // The following are not canned tests but still useful
@@ -127,7 +127,7 @@ variables.RateV4 = variables.usps.RateV4(
 	Pounds = '0',
 	Ounces = '3.5'
 );
-WriteDump(var="#variables.RateV4#" label="RateV4");
+WriteDump(var="#variables.RateV4#", label="RateV4");
 
 variables.IntlRateV2 = variables.usps.IntlRateV2(
 	Pounds = '15',
@@ -144,7 +144,7 @@ variables.IntlRateV2 = variables.usps.IntlRateV2(
 	Country = 'Algeria',
 	CommercialFlag = 'N'
 );
-WriteDump(var="#variables.IntlRateV2#" label="IntlRateV2");
+WriteDump(var="#variables.IntlRateV2#", label="IntlRateV2");
 
 </cfscript>
 


### PR DESCRIPTION
WriteDump() on Lucee requires 'var=' and 'label=' params to be separated by a comma